### PR TITLE
Feature: Add Top Weekly Dapps in Leaderboards

### DIFF
--- a/src/services/near/indexer/types.ts
+++ b/src/services/near/indexer/types.ts
@@ -185,3 +185,8 @@ export interface CachedAccountRecord {
   balance: string;
   score: number;
 }
+
+export interface NearWeekCachedStats {
+  account_id: string;
+  number_of_transactions: number;
+}

--- a/src/views/Leaderboards.vue
+++ b/src/views/Leaderboards.vue
@@ -2,6 +2,10 @@
   <main class="flex-grow flex flex-col space-y-3">
     <LeaderboardTableCard title="Rich List" :records="balanceLeaderboard" />
     <LeaderboardTableCard title="Top Score" :records="scoreLeaderboard" />
+    <LeaderboardTableCard
+      title="Weekly Top Active"
+      :records="transactionsLeaderBoard"
+    />
   </main>
 </template>
 
@@ -14,7 +18,10 @@
 <script lang="ts">
 import { useMultiple } from '@/composables/useMultiple';
 import { Network } from '@/services/near/indexer/networks';
-import { CachedAccountRecord } from '@/services/near/indexer/types';
+import {
+  CachedAccountRecord,
+  NearWeekCachedStats,
+} from '@/services/near/indexer/types';
 import { Timeframe } from '@/utils/timeframe';
 import { defineComponent } from 'vue';
 import LeaderboardTableCard from './leaderboards/LeaderboardTableCard.vue';
@@ -44,9 +51,20 @@ export default defineComponent({
       [],
     );
 
+    const { value: transactionsLeaderBoard } = useMultiple<NearWeekCachedStats>(
+      'leaderboard-transactions-week',
+      {
+        account: '',
+        network: Network.MAINNET,
+        timeframe: Timeframe.WEEK,
+      },
+      [],
+    );
+
     return {
       balanceLeaderboard,
       scoreLeaderboard,
+      transactionsLeaderBoard,
     };
   },
 });

--- a/src/views/landing/IntakeHero.vue
+++ b/src/views/landing/IntakeHero.vue
@@ -1,14 +1,6 @@
 <template>
   <div
-    class="
-      py-16
-      lg:py-64
-      flex flex-col
-      items-center
-      relative
-      overflow-hidden
-      -mb-16
-    "
+    class="py-16 lg:py-64 flex flex-col items-center relative overflow-hidden -mb-16"
   >
     <Chart :option="chartOption" class="bg-chart" autoresize />
     <h1 class="font-bold text-white text-4xl lg:text-6xl mb-5 mx-4 text-center">
@@ -19,14 +11,7 @@
       and {{ $filters.number.standard(allAccounts) }} other accounts
     </p>
     <div
-      class="
-        flex flex-col
-        lg:flex-row
-        flex-shrink-0
-        lg:space-x-4
-        items-stretch
-        lg:items-start
-      "
+      class="flex flex-col lg:flex-row flex-shrink-0 lg:space-x-4 items-stretch lg:items-start"
     >
       <div class="flex flex-col flex-shrink-0">
         <TextInput
@@ -94,7 +79,10 @@ import { useNetworkActivityChart } from '@/composables/charts/useNetworkActivity
 import { useMultiple } from '@/composables/useMultiple';
 import { useSingle } from '@/composables/useSingle';
 import { Network } from '@/services/near/indexer/networks';
-import { CachedAccountRecord } from '@/services/near/indexer/types';
+import {
+  CachedAccountRecord,
+  NearWeekCachedStats,
+} from '@/services/near/indexer/types';
 import { Timeframe } from '@/utils/timeframe';
 import { defineComponent, ref, watch } from 'vue';
 import { useRouter } from 'vue-router';
@@ -165,11 +153,31 @@ export default defineComponent({
       [],
     );
 
+    const { value: transactionsLeaderboard } = useMultiple<NearWeekCachedStats>(
+      'leaderboard-transactions-week',
+      {
+        account: '',
+        network: Network.MAINNET,
+        timeframe: Timeframe.WEEK,
+      },
+      [],
+    );
+
     const accountsJumble = ref<string[]>([]);
 
     watch(
-      [newAccounts, scoreLeaderboard, balanceLeaderboard],
-      ([newAccounts, scoreLeaderboard, balanceLeaderboard]) => {
+      [
+        newAccounts,
+        scoreLeaderboard,
+        balanceLeaderboard,
+        transactionsLeaderboard,
+      ],
+      ([
+        newAccounts,
+        scoreLeaderboard,
+        balanceLeaderboard,
+        transactionsLeaderboard,
+      ]) => {
         const a = [];
         for (let i = 0; i < 10; i++) {
           const randomArray = [

--- a/src/views/leaderboards/LeaderboardRow.vue
+++ b/src/views/leaderboards/LeaderboardRow.vue
@@ -9,6 +9,7 @@
       <account-link :account="record.account_id" />
     </div>
     <div
+      v-if="record.balance !== undefined"
       class="w-3/12 flex items-center justify-start px-2 font-medium"
       style="min-width: 4em"
     >
@@ -16,8 +17,19 @@
         $filters.number.compact(+$filters.toNear(record.balance))
       }}
     </div>
-    <div class="w-2/12 px-2 font-medium" style="min-width: 4em">
+    <div
+      v-if="record.balance !== undefined"
+      class="w-2/12 px-2 font-medium"
+      style="min-width: 4em"
+    >
       {{ $filters.number.compact(record.score) }}
+    </div>
+    <div
+      v-if="record.number_of_transactions !== undefined"
+      class="w-2/12 px-2 font-medium"
+      style="min-width: 4em"
+    >
+      {{ $filters.number.compact(record.number_of_transactions) }}
     </div>
   </div>
 </template>

--- a/src/views/leaderboards/LeaderboardTableCard.vue
+++ b/src/views/leaderboards/LeaderboardTableCard.vue
@@ -2,22 +2,31 @@
   <DashboardCard :title="title">
     <div class="p-3 flex flex-col">
       <div
-        class="
-          flex
-          relative
-          font-bold
-          bg-gray-100
-          dark:bg-gray-700
-          py-2
-          mb-3
-          rounded
-          truncate
-        "
+        class="flex relative font-bold bg-gray-100 dark:bg-gray-700 py-2 mb-3 rounded truncate"
       >
         <div class="px-2 w-1/12 hidden sm:block">Rank</div>
         <div class="px-2 flex-1">Account</div>
-        <div class="px-2 w-3/12" style="min-width: 4em">Balance</div>
-        <div class="px-2 w-2/12" style="min-width: 4em">Score</div>
+        <div
+          v-if="records[0] && records[0].balance !== undefined"
+          class="px-2 w-3/12"
+          style="min-width: 4em"
+        >
+          Balance
+        </div>
+        <div
+          v-if="records[0] && records[0].score !== undefined"
+          class="px-2 w-2/12"
+          style="min-width: 4em"
+        >
+          Score
+        </div>
+        <div
+          v-if="records[0] && records[0].number_of_transactions !== undefined"
+          class="px-2 w-3/12"
+          style="min-width: 4em"
+        >
+          Number of Transactions
+        </div>
       </div>
       <div class="flex flex-col divide-y divide-gray-100 dark:divide-gray-700">
         <LeaderboardRow
@@ -32,7 +41,10 @@
 </template>
 
 <script lang="ts">
-import { CachedAccountRecord } from '@/services/near/indexer/types';
+import {
+  CachedAccountRecord,
+  NearWeekCachedStats,
+} from '@/services/near/indexer/types';
 import { defineComponent, PropType } from 'vue';
 import DashboardCard from '../overview/DashboardCard.vue';
 import LeaderboardRow from './LeaderboardRow.vue';
@@ -45,7 +57,7 @@ export default defineComponent({
       required: true,
     },
     records: {
-      type: Object as PropType<CachedAccountRecord[]>,
+      type: Object as PropType<CachedAccountRecord[] | NearWeekCachedStats[]>,
       required: true,
     },
     limit: {


### PR DESCRIPTION
Changelog:
- Implemented Weekly Top Transactions endpoint
- Added conditional rendering to only display necessary data when present
- Added new interface called `NearWeekStats`

Functional tests:
![sample](https://user-images.githubusercontent.com/22711718/147908434-27a07a1c-a4dc-4c8a-b395-89f36fc58ff4.png)

